### PR TITLE
Fix PWD usage

### DIFF
--- a/docker-compose/docker-compose-graphdb.yml
+++ b/docker-compose/docker-compose-graphdb.yml
@@ -23,7 +23,7 @@ services:
     hostname: quad-server
     container_name: quad-server
     env_file:
-      - ${PWD}/env/mms5-quad-store-graphdb.env
+      - ./env/mms5-quad-store-graphdb.env
     command: -Dgraphdb.global.page.cache=true
     ports:
       - 7200:7200
@@ -44,8 +44,8 @@ services:
     hostname: auth-service
     container_name: auth-service
     env_file:
-      - ${PWD}/env/mms5-jwt.env
-      - ${PWD}/env/mms5-auth-graphdb.env
+      - ./env/mms5-jwt.env
+      - ./env/mms5-auth-graphdb.env
     depends_on:
       - openldap-server
       - quad-store-server
@@ -57,8 +57,8 @@ services:
     hostname: store-service
     container_name: store-service
     env_file:
-      - ${PWD}/env/mms5-jwt.env
-      - ${PWD}/env/mms5-store.env
+      - ./env/mms5-jwt.env
+      - ./env/mms5-store.env
     depends_on:
       - minio-server
     ports:
@@ -69,8 +69,8 @@ services:
     hostname: layer1-service
     container_name: layer1-service
     env_file:
-      - ${PWD}/env/mms5-jwt.env
-      - ${PWD}/env/mms5-layer1-graphdb.env
+      - ./env/mms5-jwt.env
+      - ./env/mms5-layer1-graphdb.env
     depends_on:
       - store-service
       - auth-service

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -23,10 +23,10 @@ services:
     hostname: quad-server
     container_name: quad-server
     env_file:
-      - ${PWD}/env/mms5-quad-store.env
+      - ./env/mms5-quad-store.env
     command: --file=/tmp/mount/cluster.trig --update /ds
     volumes:
-      - ${PWD}/mount:/tmp/mount
+      - ./mount:/tmp/mount
     ports:
       - 3030:3030
 
@@ -46,8 +46,8 @@ services:
     hostname: auth-service
     container_name: auth-service
     env_file:
-      - ${PWD}/env/mms5-jwt.env
-      - ${PWD}/env/mms5-auth.env
+      - ./env/mms5-jwt.env
+      - ./env/mms5-auth.env
     depends_on:
       - openldap-server
       - quad-store-server
@@ -59,8 +59,8 @@ services:
     hostname: store-service
     container_name: store-service
     env_file:
-      - ${PWD}/env/mms5-jwt.env
-      - ${PWD}/env/mms5-store.env
+      - ./env/mms5-jwt.env
+      - ./env/mms5-store.env
     depends_on:
       - minio-server
     ports:
@@ -71,8 +71,8 @@ services:
     hostname: layer1-service
     container_name: layer1-service
     env_file:
-      - ${PWD}/env/mms5-jwt.env
-      - ${PWD}/env/mms5-layer1.env
+      - ./env/mms5-jwt.env
+      - ./env/mms5-layer1.env
     depends_on:
       - store-service
       - auth-service


### PR DESCRIPTION
Fixes the use of `${PWD}` for consistency on all platforms (i.e., Windows).

More information can be found here:
https://devops.stackexchange.com/questions/9002/docker-compose-volume-syntax-valid-for-windows-and-linux